### PR TITLE
Adding license information in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "test": "cake spec"
   },
+  "license": "MIT",
   "dependencies": {},
   "devDependencies": {
     "jasmine-node": "~1.0.26",


### PR DESCRIPTION
This adds license information in the package.json, making it easier for automated requests to determine the license of your library.