### PR TITLE
Add `files` to `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "git://github.com/jimmycuadra/shellwords.git"
   },
   "main": "./lib/shellwords",
+  "files": ["lib"],
   "scripts": {
     "test": "cake spec"
   },


### PR DESCRIPTION
Prevents `spec`, `src`, and `Cakefile` from being published to NPM.